### PR TITLE
Ensures resp.Body is Close()d if we get an error

### DIFF
--- a/avatars.go
+++ b/avatars.go
@@ -34,10 +34,14 @@ func GetSkin(u User) (Skin, error) {
 
 func FetchSkinFromUrl(url, username string) (Skin, error) {
 	resp, err := http.Get(url + username + ".png")
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return Skin{}, errors.New("Skin not found. (" + fmt.Sprintf("%v", resp) + ")")
+	if err != nil {
+		return Skin{}, err
 	}
 	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		return Skin{}, errors.New("Skin not found. (" + fmt.Sprintf("%v", resp) + ")")
+	}
 
 	return DecodeSkin(resp.Body)
 }


### PR DESCRIPTION
Before, if we got an HTTP error we would never close the socket. This is problematic.
